### PR TITLE
provision sentry-dsn K8s Secret via Ansible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ infra/inventory/group_vars/secrets.sops.yml.plaintext
 *.swo
 .idea/
 .vscode/
-/docs/superpowers/

--- a/APPS.md
+++ b/APPS.md
@@ -111,7 +111,7 @@ Adjust based on actual workload. Check `kubectl top pods -n apps` after deploy.
 
 ## Multi-Architecture Requirements
 
-The cluster runs ARM64 nodes (raspi5, raspi4) and will include amd64 nodes (mba1, mba2) post-M5.
+The cluster currently runs four Ready nodes: ARM64 `raspi5` (8 GB) and `raspi4` (4 GB), plus AMD64 `mba1` (8 CPU, ~8 Gi RAM) and `mba2` (4 CPU, ~8 Gi RAM).
 **All container images must support both architectures** (`linux/arm64` and `linux/amd64`).
 
 Check whether an image is multi-arch before using it:
@@ -251,7 +251,7 @@ Ensure `kubectl` is configured to talk to the homelab cluster:
 
 ```bash
 export KUBECONFIG=~/.kube/homelab.yaml
-kubectl get nodes  # should show raspi5 + raspi4 as Ready
+kubectl get nodes  # should show raspi5, raspi4, mba1, mba2 as Ready
 ```
 
 > Add `export KUBECONFIG=~/.kube/homelab.yaml` to your `~/.zshrc` to make it permanent.

--- a/docs/superpowers/plans/2026-03-31-m6-apps-homeassistant.md
+++ b/docs/superpowers/plans/2026-03-31-m6-apps-homeassistant.md
@@ -1,0 +1,796 @@
+# M6: App Infrastructure + Home Assistant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy PostgreSQL 17, InfluxDB 2, Mosquitto 2 in the `apps` namespace and Home Assistant in the `homeassistant` namespace, all accessible on the LAN, with Longhorn PVCs for persistence.
+
+**Architecture:** Two new playbooks (`50_apps_infra.yml`, `51_homeassistant.yml`) following the established `40_platform.yml` pattern (delegate_to: localhost, Helm via helm_binary). Mosquitto deployed as raw Kubernetes manifests (no Helm — k8s-at-home chart is archived). Home Assistant deployed via pajikos Helm chart with `hostNetwork: true` for mDNS discovery.
+
+**Tech Stack:** Ansible `kubernetes.core.helm` + `kubernetes.core.k8s`, bitnami/postgresql, influxdata/influxdb2, eclipse/mosquitto:2.0.x (raw manifests), pajikos/home-assistant Helm chart, SOPS+age for secrets, Longhorn PVCs.
+
+> **CLAUDE.md requirement:** Before implementing, create a worklog at `.agent/worklogs/YYYYMMDD-HHMMSS-m6-apps-homeassistant-<rand4>.md` and follow the 5-phase workflow. This plan covers Phase 4 (implement) in detail.
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|---|---|---|
+| Create | `infra/playbooks/50_apps_infra.yml` | PostgreSQL + InfluxDB + Mosquitto deploy |
+| Create | `infra/playbooks/51_homeassistant.yml` | Home Assistant deploy |
+| Create | `cluster/values/postgresql.yaml` | bitnami/postgresql Helm values |
+| Create | `cluster/values/influxdb2.yaml` | influxdata/influxdb2 Helm values |
+| Create | `cluster/values/home-assistant.yaml` | pajikos/home-assistant Helm values |
+| Modify | `infra/inventory/group_vars/all.sops.yml` | Add 4 new secrets |
+| Modify | `infra/inventory/group_vars/all.sops.yml.example` | Document new secrets |
+| Modify | `infra/inventory/group_vars/all.yml` | Remove obsolete `ha_host` variable |
+| Modify | `docs/01-homelab-platform.md` | Update M6 status |
+| Modify | `README.md` | Mark M6 done |
+| Modify | `OPERATIONS.md` | Add app-infra + HA runbooks |
+| Modify | `APPS.md` | Update with deployed services |
+| Modify | `.agent/memory.md` | Add M6-DONE entry |
+
+---
+
+## Part 1: App Infrastructure (`50_apps_infra.yml`)
+
+---
+
+### Task 1: Research — Pin Helm chart versions
+
+**Files:** None changed — output feeds into Tasks 3–5.
+
+- [ ] **Step 1: Add Helm repos and search for latest chart versions**
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add influxdata https://helm.influxdata.com/
+helm repo update
+helm search repo bitnami/postgresql --versions | head -5
+helm search repo influxdata/influxdb2 --versions | head -5
+```
+
+Expected: table with `CHART VERSION` and `APP VERSION`. Record the latest chart version that ships **PostgreSQL 17.x** and the latest **influxdb2 2.x** chart.
+
+- [ ] **Step 2: Search for pajikos/home-assistant chart version**
+
+```bash
+helm repo add pajikos https://pajikos.github.io/home-assistant-helm-chart/
+helm repo update
+helm search repo pajikos/home-assistant --versions | head -5
+```
+
+Expected: table with latest chart version. Record it.
+
+- [ ] **Step 3: Find latest eclipse/mosquitto image tag**
+
+```bash
+# Check https://hub.docker.com/_/eclipse-mosquitto/tags for latest 2.0.x tag
+# At time of writing: 2.0.21 — verify and record current patch version
+```
+
+- [ ] **Step 4: Record versions**
+
+Write the four pinned versions into the worklog (§1 research):
+```
+bitnami/postgresql chart: X.Y.Z  (app: 17.x)
+influxdata/influxdb2 chart: X.Y.Z
+pajikos/home-assistant chart: X.Y.Z
+eclipse/mosquitto image: 2.0.X
+```
+
+These replace every `X.Y.Z` placeholder in the tasks below.
+
+---
+
+### Task 2: Add new secrets to all.sops.yml
+
+**Files:**
+- Modify: `infra/inventory/group_vars/all.sops.yml` (decrypt → edit → re-encrypt)
+- Modify: `infra/inventory/group_vars/all.sops.yml.example`
+
+- [ ] **Step 1: Decrypt the SOPS file for editing**
+
+```bash
+sops infra/inventory/group_vars/all.sops.yml
+```
+
+This opens the file in `$EDITOR`. Add the following four variables at the end:
+
+```yaml
+# PostgreSQL — Passwörter für Primary und Replication
+# Generieren: openssl rand -base64 24
+postgresql_password: "CHANGE_ME_generate_with_openssl_rand"
+postgresql_replication_password: "CHANGE_ME_generate_with_openssl_rand"
+
+# InfluxDB 2 — Admin-Passwort (min 8 Zeichen) und API-Token
+# Token generieren: openssl rand -hex 32
+influxdb_admin_password: "CHANGE_ME_min_8_zeichen"
+influxdb_admin_token: "CHANGE_ME_generate_with_openssl_rand_hex_32"
+```
+
+Save and exit. SOPS re-encrypts automatically on save.
+
+- [ ] **Step 2: Verify the secrets are accessible**
+
+```bash
+sops -d infra/inventory/group_vars/all.sops.yml | grep -E "postgresql|influxdb"
+```
+
+Expected: four lines with the values you entered (plaintext in terminal only, never in git).
+
+- [ ] **Step 3: Update all.sops.yml.example**
+
+Add the same four entries to `infra/inventory/group_vars/all.sops.yml.example` with `CHANGE_ME` placeholders and generation instructions (match the style of existing entries in that file):
+
+```yaml
+# PostgreSQL Passwörter
+# Generieren: openssl rand -base64 24
+postgresql_password: "CHANGE_ME_generate_with_openssl_rand"
+postgresql_replication_password: "CHANGE_ME_generate_with_openssl_rand"
+
+# InfluxDB 2 Admin-Passwort und API Token
+# Passwort: mind. 8 Zeichen
+# Token generieren: openssl rand -hex 32
+influxdb_admin_password: "CHANGE_ME_min_8_zeichen"
+influxdb_admin_token: "CHANGE_ME_openssl_rand_hex_32"
+```
+
+---
+
+### Task 3: Create PostgreSQL Helm values
+
+**Files:**
+- Create: `cluster/values/postgresql.yaml`
+
+- [ ] **Step 1: Verify no existing postgresql values file exists**
+
+```bash
+ls cluster/values/
+```
+
+Expected: no `postgresql.yaml` listed.
+
+- [ ] **Step 2: Create `cluster/values/postgresql.yaml`**
+
+```yaml
+---
+# PostgreSQL Helm Values
+# Chart: bitnami/postgresql vX.Y.Z  ← replace with version from Task 1
+#
+# auth.postgresPassword + auth.replicationPassword:
+#   injected from 50_apps_infra.yml via all.sops.yml — not stored here.
+#
+# Storage: 5Gi Longhorn (default StorageClass — no storageClassName needed).
+# Replicas: 0 read replicas (single primary, homelab workload).
+
+auth:
+  database: "postgres"
+
+primary:
+  persistence:
+    enabled: true
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+readReplicas:
+  replicaCount: 0
+```
+
+- [ ] **Step 3: Lint the values file**
+
+```bash
+helm lint cluster/values/postgresql.yaml 2>/dev/null || echo "values-only file, lint via template"
+helm template postgresql bitnami/postgresql \
+  --version X.Y.Z \
+  -f cluster/values/postgresql.yaml \
+  --set auth.postgresPassword=test \
+  --set auth.replicationPassword=test \
+  | head -40
+```
+
+Expected: YAML output with a StatefulSet for postgresql, no errors.
+
+---
+
+### Task 4: Create InfluxDB 2 Helm values
+
+**Files:**
+- Create: `cluster/values/influxdb2.yaml`
+
+- [ ] **Step 1: Create `cluster/values/influxdb2.yaml`**
+
+```yaml
+---
+# InfluxDB 2 Helm Values
+# Chart: influxdata/influxdb2 vX.Y.Z  ← replace with version from Task 1
+#
+# adminUser.password + adminUser.token:
+#   injected from 50_apps_infra.yml via all.sops.yml — not stored here.
+#
+# Storage: 10Gi Longhorn (default StorageClass).
+
+adminUser:
+  organization: "homelab"
+  bucket: "default"
+  retention_policy: "30d"
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+- [ ] **Step 2: Render template to verify**
+
+```bash
+helm template influxdb2 influxdata/influxdb2 \
+  --version X.Y.Z \
+  -f cluster/values/influxdb2.yaml \
+  --set adminUser.password=testpassword \
+  --set adminUser.token=testtoken \
+  | head -40
+```
+
+Expected: YAML output with a StatefulSet or Deployment for influxdb2, no errors.
+
+---
+
+### Task 5: Create Mosquitto Kubernetes manifests (inline in playbook)
+
+Mosquitto is deployed as raw Kubernetes manifests (no Helm chart — k8s-at-home is archived). The manifests are defined inline in `50_apps_infra.yml` via `kubernetes.core.k8s`. A LoadBalancer Service exposes port 1883 on the node IP for LAN IoT devices; in-cluster services (HA) use `mosquitto.apps.svc.cluster.local:1883`.
+
+**Files:**
+- No separate file — manifests live inline in `50_apps_infra.yml` (next task).
+
+- [ ] **Step 1: Note the mosquitto image tag from Task 1 research**
+
+The Deployment will use `eclipse-mosquitto:2.0.X` — replace X with the tag found in Task 1.
+
+---
+
+### Task 6: Create `infra/playbooks/50_apps_infra.yml`
+
+**Files:**
+- Create: `infra/playbooks/50_apps_infra.yml`
+
+- [ ] **Step 1: Create the playbook**
+
+```yaml
+---
+# App Infrastructure: PostgreSQL 17, InfluxDB 2, Mosquitto 2
+# Namespace: apps
+#
+# Voraussetzung: 30_longhorn.yml ausgeführt (Longhorn Default StorageClass)
+# Voraussetzung: all.sops.yml enthält postgresql_password, postgresql_replication_password,
+#                influxdb_admin_password, influxdb_admin_token
+#
+# Ausführen: ansible-playbook infra/playbooks/50_apps_infra.yml
+- name: App Infrastructure — PostgreSQL, InfluxDB 2, Mosquitto
+  hosts: k3s_server
+  gather_facts: false
+  run_once: true
+  vars:
+    kubeconfig: "{{ lookup('env', 'HOME') }}/.kube/homelab.yaml"
+    apps_namespace: apps
+
+  tasks:
+    # --- Namespace ---
+    - name: Apps Namespace anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ apps_namespace }}"
+      delegate_to: localhost
+
+    # --- PostgreSQL ---
+    - name: Bitnami Helm Repo hinzufügen
+      kubernetes.core.helm_repository:
+        name: bitnami
+        repo_url: https://charts.bitnami.com/bitnami
+        binary_path: "{{ helm_binary }}"
+      delegate_to: localhost
+
+    - name: PostgreSQL deployen
+      kubernetes.core.helm:
+        name: postgresql
+        chart_ref: bitnami/postgresql
+        chart_version: "X.Y.Z"  # ← pin from Task 1
+        release_namespace: "{{ apps_namespace }}"
+        kubeconfig: "{{ kubeconfig }}"
+        binary_path: "{{ helm_binary }}"
+        values_files:
+          - "{{ playbook_dir }}/../../cluster/values/postgresql.yaml"
+        values:
+          auth:
+            postgresPassword: "{{ postgresql_password }}"
+            replicationPassword: "{{ postgresql_replication_password }}"
+        wait: true
+        wait_timeout: "5m"
+      delegate_to: localhost
+
+    # --- InfluxDB 2 ---
+    - name: InfluxData Helm Repo hinzufügen
+      kubernetes.core.helm_repository:
+        name: influxdata
+        repo_url: https://helm.influxdata.com/
+        binary_path: "{{ helm_binary }}"
+      delegate_to: localhost
+
+    - name: InfluxDB 2 deployen
+      kubernetes.core.helm:
+        name: influxdb2
+        chart_ref: influxdata/influxdb2
+        chart_version: "X.Y.Z"  # ← pin from Task 1
+        release_namespace: "{{ apps_namespace }}"
+        kubeconfig: "{{ kubeconfig }}"
+        binary_path: "{{ helm_binary }}"
+        values_files:
+          - "{{ playbook_dir }}/../../cluster/values/influxdb2.yaml"
+        values:
+          adminUser:
+            password: "{{ influxdb_admin_password }}"
+            token: "{{ influxdb_admin_token }}"
+        wait: true
+        wait_timeout: "5m"
+      delegate_to: localhost
+
+    # --- Mosquitto (raw manifests — no Helm chart, k8s-at-home archived) ---
+    - name: Mosquitto ConfigMap anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: mosquitto-config
+            namespace: "{{ apps_namespace }}"
+          data:
+            mosquitto.conf: |
+              listener 1883
+              allow_anonymous true
+              persistence true
+              persistence_location /mosquitto/data/
+              log_dest stdout
+      delegate_to: localhost
+
+    - name: Mosquitto PVC anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: mosquitto-data
+            namespace: "{{ apps_namespace }}"
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources:
+              requests:
+                storage: 1Gi
+      delegate_to: localhost
+
+    - name: Mosquitto Deployment anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: mosquitto
+            namespace: "{{ apps_namespace }}"
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: mosquitto
+            template:
+              metadata:
+                labels:
+                  app: mosquitto
+              spec:
+                containers:
+                  - name: mosquitto
+                    image: "eclipse-mosquitto:2.0.X"  # ← pin from Task 1
+                    ports:
+                      - containerPort: 1883
+                    volumeMounts:
+                      - name: config
+                        mountPath: /mosquitto/config
+                      - name: data
+                        mountPath: /mosquitto/data
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: 64Mi
+                      limits:
+                        cpu: 200m
+                        memory: 128Mi
+                volumes:
+                  - name: config
+                    configMap:
+                      name: mosquitto-config
+                  - name: data
+                    persistentVolumeClaim:
+                      claimName: mosquitto-data
+      delegate_to: localhost
+
+    - name: Mosquitto Service anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: mosquitto
+            namespace: "{{ apps_namespace }}"
+          spec:
+            type: LoadBalancer
+            selector:
+              app: mosquitto
+            ports:
+              - port: 1883
+                targetPort: 1883
+                protocol: TCP
+      delegate_to: localhost
+```
+
+- [ ] **Step 2: Ansible lint**
+
+```bash
+ansible-lint infra/playbooks/50_apps_infra.yml
+```
+
+Expected: no violations (or only warnings about `latest` — there is none here since versions are pinned).
+
+- [ ] **Step 3: Dry-run against raspi5**
+
+```bash
+ansible-playbook infra/playbooks/50_apps_infra.yml --check --diff
+```
+
+Expected: tasks show as `changed` (namespace, repos, Helm releases, manifests). No errors. Note: Helm tasks may show "skipped" in check mode — that is expected behaviour.
+
+---
+
+### Task 7: Deploy and validate app infrastructure
+
+- [ ] **Step 1: Pre-flight — confirm Longhorn is default StorageClass**
+
+```bash
+kubectl get storageclass
+```
+
+Expected: `longhorn` has `(default)` annotation. `local-path` does not.
+
+- [ ] **Step 2: Deploy**
+
+```bash
+ansible-playbook infra/playbooks/50_apps_infra.yml
+```
+
+Expected: all tasks `ok` or `changed`, no failures. `PLAY RECAP` shows `failed=0`.
+
+- [ ] **Step 3: Validate PostgreSQL**
+
+```bash
+kubectl get pods -n apps -l app.kubernetes.io/name=postgresql
+```
+
+Expected: `postgresql-0` in `Running` state, `1/1` ready.
+
+```bash
+kubectl exec -n apps postgresql-0 -- psql -U postgres -c "\l"
+```
+
+Expected: list of databases including `postgres`. (May need `-c "select 1"` first if psql isn't directly available — use `kubectl exec -n apps postgresql-0 -- env PGPASSWORD=<your-password> psql -U postgres -c "\l"`)
+
+- [ ] **Step 4: Validate InfluxDB 2**
+
+```bash
+kubectl get pods -n apps -l app.kubernetes.io/name=influxdb2
+```
+
+Expected: pod in `Running` state, `1/1` ready.
+
+```bash
+kubectl port-forward -n apps svc/influxdb2 8086:8086 &
+curl -s http://localhost:8086/ping
+kill %1
+```
+
+Expected: HTTP 204 response from `/ping`.
+
+- [ ] **Step 5: Validate Mosquitto**
+
+```bash
+kubectl get pods -n apps -l app=mosquitto
+kubectl get svc -n apps mosquitto
+```
+
+Expected: pod `Running`, service shows `TYPE=LoadBalancer` with an `EXTERNAL-IP` (the node IP assigned by k3s ServiceLB).
+
+```bash
+# From your Mac on the LAN (install mosquitto-clients if needed: brew install mosquitto)
+MQTT_IP=$(kubectl get svc -n apps mosquitto -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+mosquitto_sub -h $MQTT_IP -p 1883 -t test/# &
+mosquitto_pub -h $MQTT_IP -p 1883 -t test/hello -m "world"
+```
+
+Expected: subscriber receives `world` on `test/hello`. Kill background sub with `kill %1`.
+
+- [ ] **Step 6: Idempotency check**
+
+```bash
+ansible-playbook infra/playbooks/50_apps_infra.yml
+```
+
+Expected: `PLAY RECAP` shows `changed=0` (or only 1 for Helm repo update). `failed=0`.
+
+---
+
+## Part 2: Home Assistant (`51_homeassistant.yml`)
+
+---
+
+### Task 8: Create Home Assistant Helm values
+
+**Files:**
+- Create: `cluster/values/home-assistant.yaml`
+
+- [ ] **Step 1: Create `cluster/values/home-assistant.yaml`**
+
+```yaml
+---
+# Home Assistant Helm Values
+# Chart: pajikos/home-assistant vX.Y.Z  ← replace with version from Task 1
+#
+# hostNetwork: true — required for mDNS/multicast LAN device auto-discovery.
+# dnsPolicy must be ClusterFirstWithHostNet when hostNetwork is enabled.
+#
+# No Ingress — LAN access only via http://<node-ip>:8123
+# (hostNetwork means port 8123 is directly on the node IP)
+#
+# Storage: 5Gi Longhorn PVC for /config (HA config, automations, history).
+# No credentials in this file — HA manages its own users in /config.
+
+hostNetwork: true
+dnsPolicy: ClusterFirstWithHostNet
+
+env:
+  - name: TZ
+    value: "Europe/Zurich"
+
+persistence:
+  config:
+    enabled: true
+    size: 5Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+ingress:
+  enabled: false
+```
+
+- [ ] **Step 2: Render template to verify hostNetwork is set**
+
+```bash
+helm template home-assistant pajikos/home-assistant \
+  --version X.Y.Z \
+  -f cluster/values/home-assistant.yaml \
+  | grep -A2 "hostNetwork"
+```
+
+Expected: `hostNetwork: true` in the rendered Pod spec.
+
+---
+
+### Task 9: Create `infra/playbooks/51_homeassistant.yml`
+
+**Files:**
+- Create: `infra/playbooks/51_homeassistant.yml`
+
+- [ ] **Step 1: Create the playbook**
+
+```yaml
+---
+# Home Assistant in k3s
+# Namespace: homeassistant
+#
+# Voraussetzung: 30_longhorn.yml ausgeführt (Longhorn Default StorageClass)
+# Voraussetzung: 50_apps_infra.yml ausgeführt (Mosquitto läuft in apps namespace)
+#
+# Zugriff: http://<node-ip>:8123 (LAN only, hostNetwork)
+# MQTT: mosquitto.apps.svc.cluster.local:1883 (anonym, in-cluster)
+#
+# Ausführen: ansible-playbook infra/playbooks/51_homeassistant.yml
+- name: Home Assistant
+  hosts: k3s_server
+  gather_facts: false
+  run_once: true
+  vars:
+    kubeconfig: "{{ lookup('env', 'HOME') }}/.kube/homelab.yaml"
+    ha_namespace: homeassistant
+
+  tasks:
+    # --- Namespace ---
+    - name: homeassistant Namespace anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ ha_namespace }}"
+      delegate_to: localhost
+
+    # --- Home Assistant ---
+    - name: pajikos Helm Repo hinzufügen
+      kubernetes.core.helm_repository:
+        name: pajikos
+        repo_url: https://pajikos.github.io/home-assistant-helm-chart/
+        binary_path: "{{ helm_binary }}"
+      delegate_to: localhost
+
+    - name: Home Assistant deployen
+      kubernetes.core.helm:
+        name: home-assistant
+        chart_ref: pajikos/home-assistant
+        chart_version: "X.Y.Z"  # ← pin from Task 1
+        release_namespace: "{{ ha_namespace }}"
+        kubeconfig: "{{ kubeconfig }}"
+        binary_path: "{{ helm_binary }}"
+        values_files:
+          - "{{ playbook_dir }}/../../cluster/values/home-assistant.yaml"
+        wait: true
+        wait_timeout: "5m"
+      delegate_to: localhost
+```
+
+- [ ] **Step 2: Ansible lint**
+
+```bash
+ansible-lint infra/playbooks/51_homeassistant.yml
+```
+
+Expected: no violations.
+
+- [ ] **Step 3: Dry-run**
+
+```bash
+ansible-playbook infra/playbooks/51_homeassistant.yml --check --diff
+```
+
+Expected: tasks show as `changed`, no errors.
+
+---
+
+### Task 10: Deploy and validate Home Assistant
+
+- [ ] **Step 1: Deploy**
+
+```bash
+ansible-playbook infra/playbooks/51_homeassistant.yml
+```
+
+Expected: all tasks `ok` or `changed`. `PLAY RECAP` shows `failed=0`.
+
+- [ ] **Step 2: Verify pod is running**
+
+```bash
+kubectl get pods -n homeassistant
+```
+
+Expected: `home-assistant-0` (or similar) in `Running` state, `1/1` ready.
+
+- [ ] **Step 3: Verify hostNetwork and PVC**
+
+```bash
+kubectl get pod -n homeassistant -o jsonpath='{.items[0].spec.hostNetwork}'
+```
+
+Expected: `true`
+
+```bash
+kubectl get pvc -n homeassistant
+```
+
+Expected: PVC `Bound` to a Longhorn volume.
+
+- [ ] **Step 4: Validate LAN access**
+
+```bash
+# Find node IP where HA pod is running
+kubectl get pod -n homeassistant -o wide
+```
+
+Open in browser on the LAN: `http://<node-ip>:8123`
+
+Expected: Home Assistant onboarding wizard appears ("Welcome to Home Assistant").
+
+- [ ] **Step 5: Idempotency check**
+
+```bash
+ansible-playbook infra/playbooks/51_homeassistant.yml
+```
+
+Expected: `changed=0`, `failed=0`.
+
+---
+
+### Task 11: Cleanup, docs, and memory
+
+**Files:**
+- Modify: `infra/inventory/group_vars/all.yml`
+- Modify: `docs/01-homelab-platform.md`
+- Modify: `README.md`
+- Modify: `OPERATIONS.md`
+- Modify: `APPS.md`
+- Modify: `.agent/memory.md`
+
+- [ ] **Step 1: Remove obsolete `ha_host` from all.yml**
+
+In `infra/inventory/group_vars/all.yml`, remove the `ha_host` variable and its comment block:
+
+```yaml
+# DELETE these two lines:
+# ha_host: Node auf dem Docker + Home Assistant läuft (ausserhalb k3s)
+# Gesetzt auf mba1 — kann bei Bedarf auf anderen Node geändert werden
+ha_host: "mba1"
+```
+
+HA now runs in k3s (`homeassistant` namespace). The variable is no longer used.
+
+- [ ] **Step 2: Invoke doc-auditor subagent**
+
+Per CLAUDE.md Phase 5 requirement: invoke the `doc-auditor` subagent to check `README.md`, `OPERATIONS.md`, `CONTRIBUTING.md`, and `APPS.md`. Implement all changes it identifies.
+
+Key expected updates:
+- `README.md`: Mark M6 ✅ done in Milestones table
+- `OPERATIONS.md`: Add runbooks for PostgreSQL, InfluxDB 2, Mosquitto, Home Assistant
+- `APPS.md`: Update with deployed services and MQTT endpoint
+- `docs/01-homelab-platform.md`: Note HA moved from Docker to k3s
+
+- [ ] **Step 3: Add M6-DONE block to `.agent/memory.md`**
+
+Insert a new block at the top of `.agent/memory.md` (above the M5-DONE block) following the established format:
+
+```
+[YYYY-MM-DD] M6-DONE — PostgreSQL 17 + InfluxDB 2 + Mosquitto 2 + Home Assistant in k3s
+Worklog: .agent/worklogs/YYYYMMDD-HHMMSS-m6-apps-homeassistant-<rand4>.md
+Was: 50_apps_infra.yml + 51_homeassistant.yml erstellt; 4 Services deployed
+Entscheidungen:
+  - Mosquitto: raw Kubernetes manifests (k8s-at-home Helm chart archived)
+  - Mosquitto Service: LoadBalancer (k3s ServiceLB) → LAN-Zugriff auf Port 1883
+  - Home Assistant: pajikos Helm chart, hostNetwork:true, namespace homeassistant
+  - ha_host Variable aus all.yml entfernt (HA nicht mehr auf Docker/mba1)
+  - MQTT auth + WSS endpoint: explizit Post-M6 deferred (→ memory)
+Kritische Fallstricke: (fill in during implementation)
+Offen:
+  - Post-M6: mqtt.furchert.ch WSS + MQTT auth als Bundle
+  - mba1/mba2 join (deferred seit M1)
+  - raspi4 SSH tunnel
+Status: done
+```

--- a/docs/superpowers/plans/2026-04-09-sentry-integration.md
+++ b/docs/superpowers/plans/2026-04-09-sentry-integration.md
@@ -1,0 +1,488 @@
+# Sentry Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Sentry error tracking to auth-service and device-service (and prepare data-service) so that unhandled exceptions and background-thread errors are automatically captured and visible in the Sentry dashboard.
+
+**Architecture:** Sentry's Spring Boot logging integration is enabled in both services — all existing `log.error(..., exception)` calls are captured automatically with no new exception-handling code. One minor fix in `SchedulerService` is required to attach the exception object to the log call so SLF4J passes it to Sentry. A shared K8s Secret `sentry-dsn` is created via Ansible (`50_apps_infra.yml`) from a SOPS-encrypted value, and referenced by both service Deployments. auth-service requires only config changes; device-service requires config changes plus the one-line `SchedulerService` fix.
+
+**Tech Stack:** `io.sentry:sentry-spring-boot-starter-jakarta:8.34.1`, Spring Boot 4.0.5, Java 25, Ansible + SOPS for secret management, K8s Secrets in `apps` namespace.
+
+---
+
+## Prerequisites (user actions before starting)
+
+1. Log in to [sentry.io](https://sentry.io) with your GitHub Student account
+2. Create a new project: **Create Project → Java → Spring Boot → name it `homelab`**
+3. Copy the DSN: **Project Settings → Client Keys (DSN) → DSN** — looks like `https://abc123@o123456.ingest.sentry.io/789`
+4. Keep the DSN handy — you will paste it into `all.sops.yml` in Task 6
+
+---
+
+## Files Changed
+
+### homelab (infrastructure repo)
+| File | Change |
+|------|--------|
+| `infrastructure/infra/playbooks/50_apps_infra.yml` | Add task: create `sentry-dsn` K8s Secret from SOPS var |
+| `infrastructure/infra/inventory/group_vars/all.sops.yml.example` | Document `sentry_dsn` variable |
+
+### auth-service repo
+| File | Change |
+|------|--------|
+| `pom.xml` | Add `sentry-spring-boot-starter-jakarta:8.34.1` dependency |
+| `src/main/resources/application.yaml` | Add `sentry:` config block |
+| `k8s/deployment.yaml` | Add `SENTRY_DSN` env var from K8s Secret |
+
+### device-service repo
+| File | Change |
+|------|--------|
+| `pom.xml` | Add `sentry-spring-boot-starter-jakarta:8.34.1` dependency |
+| `src/main/resources/application.yaml` | Add `sentry:` config block |
+| `k8s/deployment.yaml` | Add `SENTRY_DSN` env var from K8s Secret |
+| `src/main/java/ch/furchert/homelab/device/service/SchedulerService.java` | Fix log.error call at line 123: pass `e` as final arg so SLF4J attaches the stack trace |
+
+---
+
+## Task 1: Add Sentry dependency to auth-service
+
+**Repo:** `homelab-auth-service`
+
+**Files:**
+- Modify: `pom.xml`
+- Modify: `src/main/resources/application.yaml`
+
+- [ ] **Step 1: Add Sentry dependency to pom.xml**
+
+In `pom.xml`, add after the last `<dependency>` block inside `<dependencies>` (before the closing `</dependencies>` tag):
+
+```xml
+<!-- Sentry error tracking -->
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+    <version>8.34.1</version>
+</dependency>
+```
+
+- [ ] **Step 2: Add Sentry config block to application.yaml**
+
+Append to the end of `src/main/resources/application.yaml`:
+
+```yaml
+sentry:
+  dsn: ${SENTRY_DSN:}
+  environment: production
+  send-default-pii: false
+  traces-sample-rate: 0.0
+  logging:
+    enabled: true
+    minimum-event-level: ERROR
+    minimum-breadcrumb-level: WARN
+  tags:
+    service: auth-service
+```
+
+`SENTRY_DSN` defaults to empty string — Sentry is a no-op when DSN is empty, so all existing tests pass unchanged.
+
+- [ ] **Step 3: Build and run tests**
+
+```bash
+./mvnw verify
+```
+
+Expected: `BUILD SUCCESS`. If Sentry raises a startup warning about empty DSN — that is normal and expected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pom.xml src/main/resources/application.yaml
+git commit -m "feat: add Sentry error tracking (logging integration)
+
+Adds sentry-spring-boot-starter-jakarta 8.34.1. All log.error() calls
+are automatically captured as Sentry events. DSN is empty by default
+so tests are unaffected. SENTRY_DSN env var wired in k8s/deployment.yaml
+in a separate commit."
+```
+
+---
+
+## Task 2: Wire SENTRY_DSN into auth-service K8s Deployment
+
+**Repo:** `homelab-auth-service`
+
+**Files:**
+- Modify: `k8s/deployment.yaml`
+
+- [ ] **Step 1: Add SENTRY_DSN env var to deployment.yaml**
+
+In `k8s/deployment.yaml`, add to the `env:` list of the `auth-service` container (after the existing `APP_JWT_PUBLIC_KEY` entry):
+
+```yaml
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: dsn
+```
+
+Full resulting `env:` block for reference:
+
+```yaml
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-db-credentials
+                  key: password
+            - name: APP_JWT_PRIVATE_KEY
+              value: "file:/etc/secrets/private.pem"
+            - name: APP_JWT_PUBLIC_KEY
+              value: "file:/etc/secrets/public.pem"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: dsn
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/deployment.yaml
+git commit -m "feat: add SENTRY_DSN env var to auth-service K8s deployment"
+```
+
+---
+
+## Task 3: Add Sentry dependency to device-service
+
+**Repo:** `homelab-device-service`
+
+**Files:**
+- Modify: `pom.xml`
+- Modify: `src/main/resources/application.yaml`
+
+- [ ] **Step 1: Add Sentry dependency to pom.xml**
+
+In `pom.xml`, add after the last `<dependency>` block inside `<dependencies>` (before the closing `</dependencies>` tag):
+
+```xml
+<!-- Sentry error tracking -->
+<dependency>
+    <groupId>io.sentry</groupId>
+    <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+    <version>8.34.1</version>
+</dependency>
+```
+
+- [ ] **Step 2: Add Sentry config block to application.yaml**
+
+Append to the end of `src/main/resources/application.yaml`:
+
+```yaml
+sentry:
+  dsn: ${SENTRY_DSN:}
+  environment: production
+  send-default-pii: false
+  traces-sample-rate: 0.0
+  logging:
+    enabled: true
+    minimum-event-level: ERROR
+    minimum-breadcrumb-level: WARN
+  tags:
+    service: device-service
+```
+
+- [ ] **Step 3: Build and run tests**
+
+```bash
+./mvnw verify
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pom.xml src/main/resources/application.yaml
+git commit -m "feat: add Sentry error tracking (logging integration)
+
+Adds sentry-spring-boot-starter-jakarta 8.34.1. All log.error() calls
+are automatically captured as Sentry events. DSN is empty by default
+so tests are unaffected."
+```
+
+---
+
+## Task 4: Fix SchedulerService log.error call
+
+**Repo:** `homelab-device-service`
+
+**Files:**
+- Modify: `src/main/java/ch/furchert/homelab/device/service/SchedulerService.java` (line 123)
+
+**Why:** SLF4J only attaches the exception stack trace to a log event when the final argument is a `Throwable`. Currently `e.getMessage()` (a String) is passed instead of `e`, so Sentry's logging integration captures the log message but not the exception stack trace.
+
+- [ ] **Step 1: Fix the log.error call in SchedulerService**
+
+In `SchedulerService.java`, find the catch block in `reloadSchedules()` (around line 122):
+
+```java
+            } catch (IllegalArgumentException e) {
+                log.error("Invalid cron expression '{}' for schedule id={}: {}",
+                        schedule.getCronExpression(), schedule.getId(), e.getMessage());
+            }
+```
+
+Replace with:
+
+```java
+            } catch (IllegalArgumentException e) {
+                log.error("Invalid cron expression '{}' for schedule id={}: {}",
+                        schedule.getCronExpression(), schedule.getId(), e.getMessage(), e);
+            }
+```
+
+The only change is appending `, e` as the final argument — SLF4J treats a trailing `Throwable` argument specially and attaches it as the exception, which Sentry then captures with full stack trace.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+./mvnw verify
+```
+
+Expected: `BUILD SUCCESS`. The existing `SchedulerServiceTest` must still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/ch/furchert/homelab/device/service/SchedulerService.java
+git commit -m "fix: attach exception to SchedulerService log.error for Sentry capture
+
+SLF4J only forwards the stack trace to appenders (and Sentry) when the
+final argument to log.error() is a Throwable. Was passing e.getMessage()
+(String), so the exception was swallowed silently in error tracking."
+```
+
+---
+
+## Task 5: Wire SENTRY_DSN into device-service K8s Deployment
+
+**Repo:** `homelab-device-service`
+
+**Files:**
+- Modify: `k8s/deployment.yaml`
+
+- [ ] **Step 1: Add SENTRY_DSN env var to deployment.yaml**
+
+In `k8s/deployment.yaml`, add to the `env:` list of the `device-service` container (after the existing `JWKS_URI` entry):
+
+```yaml
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: dsn
+```
+
+Full resulting `env:` block for reference:
+
+```yaml
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: device-service-secrets
+                  key: db-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: device-service-secrets
+                  key: db-password
+            - name: MQTT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: device-service-secrets
+                  key: mqtt-password
+            - name: INFLUX_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: device-service-secrets
+                  key: influx-token
+            - name: MQTT_BROKER_URL
+              value: "tcp://mosquitto.apps.svc.cluster.local:1883"
+            - name: INFLUX_URL
+              value: "http://influxdb.apps.svc.cluster.local:8086"
+            - name: JWKS_URI
+              value: "http://auth-service.apps.svc.cluster.local:8080/auth/jwks"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: dsn
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/deployment.yaml
+git commit -m "feat: add SENTRY_DSN env var to device-service K8s deployment"
+```
+
+---
+
+## Task 6: Create sentry-dsn K8s Secret via Ansible
+
+**Repo:** `homelab` (infrastructure)
+
+**Files:**
+- Modify: `infrastructure/infra/playbooks/50_apps_infra.yml`
+- Modify: `infrastructure/infra/inventory/group_vars/all.sops.yml.example`
+
+**Context:** All K8s secrets that hold sensitive values are provisioned via Ansible from SOPS-encrypted variables in `all.sops.yml`. The `sentry_dsn` variable must be added there (encrypted) by the user. The Ansible task creates the K8s Secret in the `apps` namespace so it is available to both deployments.
+
+- [ ] **Step 1: Document sentry_dsn in all.sops.yml.example**
+
+In `infrastructure/infra/inventory/group_vars/all.sops.yml.example`, add a new entry in the secrets section:
+
+```yaml
+# Sentry DSN — obtain from sentry.io project settings → Client Keys
+# One DSN shared across all three homelab microservices (auth, device, data)
+sentry_dsn: "https://REPLACE_ME@oXXXXXXXX.ingest.sentry.io/XXXXXXXX"
+```
+
+- [ ] **Step 2: Add sentry_dsn to all.sops.yml**
+
+This step is a **user action** — Claude cannot touch SOPS-encrypted files.
+
+1. Get your DSN from Sentry: **Project Settings → Client Keys (DSN) → DSN**
+2. Open the encrypted file for editing:
+   ```bash
+   sops infrastructure/infra/inventory/group_vars/all.sops.yml
+   ```
+3. Add the line:
+   ```yaml
+   sentry_dsn: "https://YOUR_KEY@oXXXXXXXX.ingest.sentry.io/XXXXXXXX"
+   ```
+4. Save and close — SOPS re-encrypts automatically.
+
+- [ ] **Step 3: Add assert guard + Sentry Secret task to 50_apps_infra.yml**
+
+In `infrastructure/infra/playbooks/50_apps_infra.yml`, add both tasks after the "Apps Namespace anlegen" task (around line 28, before the `# --- PostgreSQL ---` comment). The assert must come first so the playbook fails fast if `sentry_dsn` is missing from SOPS:
+
+```yaml
+    - name: Prüfen dass sentry_dsn gesetzt ist
+      ansible.builtin.assert:
+        that:
+          - sentry_dsn is defined
+          - sentry_dsn | length > 0
+        fail_msg: >-
+          sentry_dsn ist nicht gesetzt.
+          Bitte in infra/inventory/group_vars/all.sops.yml eintragen
+          (Sentry → Project Settings → Client Keys → DSN).
+      delegate_to: localhost
+
+    # --- Sentry ---
+    - name: Sentry DSN Secret anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: sentry-dsn
+            namespace: "{{ apps_namespace }}"
+          type: Opaque
+          stringData:
+            dsn: "{{ sentry_dsn }}"
+      no_log: true
+      delegate_to: localhost
+```
+
+- [ ] **Step 5: Verify ansible-lint passes**
+
+```bash
+ansible-lint infrastructure/infra/playbooks/50_apps_infra.yml
+```
+
+Expected: 0 violations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infrastructure/infra/playbooks/50_apps_infra.yml \
+        infrastructure/infra/inventory/group_vars/all.sops.yml.example
+git commit -m "feat: provision sentry-dsn K8s Secret via Ansible
+
+Adds sentry_dsn SOPS variable and a kubernetes.core.k8s task in
+50_apps_infra.yml to create the shared sentry-dsn Secret in the apps
+namespace. Used by auth-service and device-service Deployments."
+```
+
+---
+
+## Task 7: Verify end-to-end
+
+**Repos:** homelab, homelab-auth-service, homelab-device-service
+
+- [ ] **Step 1: Run Ansible to create the K8s secret**
+
+Ensure `all.sops.yml` has `sentry_dsn` set (Task 6, Step 2), then:
+
+```bash
+ansible-playbook infrastructure/infra/playbooks/50_apps_infra.yml
+```
+
+Expected: Task "Sentry DSN Secret anlegen" → `changed` or `ok`. No failures.
+
+- [ ] **Step 2: Confirm the secret exists in the cluster**
+
+```bash
+kubectl get secret sentry-dsn -n apps
+```
+
+Expected:
+```
+NAME         TYPE     DATA   AGE
+sentry-dsn   Opaque   1      Xs
+```
+
+- [ ] **Step 3: Confirm secret has the right key**
+
+```bash
+kubectl get secret sentry-dsn -n apps -o jsonpath='{.data.dsn}' | base64 -d
+```
+
+Expected: your actual Sentry DSN URL.
+
+- [ ] **Step 4: Trigger a test error in Sentry**
+
+After deploying either service to the cluster, you can send a test event from the pod:
+
+```bash
+kubectl exec -n apps deploy/auth-service -- \
+  curl -s http://localhost:8080/actuator/health
+```
+
+Or trigger a real error scenario. Alternatively, temporarily add a test controller endpoint in auth-service that throws an exception, deploy, hit it, then remove.
+
+The simplest validation: check your Sentry project dashboard — within a few minutes of deployment, the "Issues" tab should show events if any errors occur.
+
+---
+
+## Data-Service Note
+
+When `homelab-data-service` is implemented, include Sentry from day one:
+
+1. Add `sentry-spring-boot-starter-jakarta:8.34.1` to `pom.xml` (same as above)
+2. Add the same `sentry:` block to `application.yaml` with `service: data-service`
+3. Add `SENTRY_DSN` from `sentry-dsn` secret to `k8s/deployment.yaml`
+4. The K8s Secret already exists (created by Task 6) — no Ansible change needed
+
+No background threads expected in data-service (REST + DB queries only), so logging integration alone is sufficient.

--- a/docs/superpowers/specs/2026-03-31-m6-apps-homeassistant-design.md
+++ b/docs/superpowers/specs/2026-03-31-m6-apps-homeassistant-design.md
@@ -1,0 +1,130 @@
+# M6 Design: App Infrastructure + Home Assistant
+
+**Date:** 2026-03-31
+**Status:** Approved
+
+---
+
+## Scope
+
+Two new playbooks completing Milestone 6:
+
+| Playbook | Namespace | Services |
+|---|---|---|
+| `50_apps_infra.yml` | `apps` | PostgreSQL 17, InfluxDB 2, Mosquitto 2 |
+| `51_homeassistant.yml` | `homeassistant` | Home Assistant |
+
+---
+
+## 1. Architecture
+
+### 50_apps_infra.yml — Shared App Infrastructure
+
+Three services deployed via Helm into the `apps` namespace. All use Longhorn PVCs for persistence. No external ingress (LAN-only). Credentials injected from `all.sops.yml` via `values:` dict in the playbook (same pattern as `grafana.adminPassword` in `40_platform.yml`).
+
+**Services:**
+
+| Service | Helm Chart | Namespace | PVC Size | Mount Path |
+|---|---|---|---|---|
+| PostgreSQL 17 | `bitnami/postgresql` | `apps` | 5Gi | `/bitnami/postgresql` |
+| InfluxDB 2 | `influxdata/influxdb2` | `apps` | 10Gi | `/var/lib/influxdbv2` |
+| Mosquitto 2 | `k8s-at-home/mosquitto` (primary candidate; verify availability during research) | `apps` | 1Gi | `/mosquitto/data` |
+
+**Secrets (to add to `all.sops.yml`):**
+- `postgresql_password`
+- `postgresql_replication_password`
+- `influxdb_admin_password`
+- `influxdb_admin_token`
+
+Mosquitto: anonymous auth (LAN-only, no external exposure).
+
+### 51_homeassistant.yml — Home Assistant
+
+Home Assistant deployed via Helm (`pajikos/home-assistant`) into a dedicated `homeassistant` namespace.
+
+**Key configuration:**
+- `hostNetwork: true` — required for mDNS/multicast auto-discovery of LAN devices
+- StatefulSet with Longhorn PVC (5Gi) mounted at `/config`
+- No USB device passthrough (no dongles)
+- No Ingress, no Cloudflare Tunnel — LAN access only via `http://<node-ip>:8123`
+- No node affinity — pod can float freely across cluster nodes
+
+**Mosquitto integration:**
+HA connects to Mosquitto cross-namespace: `mosquitto.apps.svc.cluster.local:1883`
+Anonymous auth (matches Mosquitto M6 config).
+
+---
+
+## 2. Playbook Structure
+
+Both playbooks follow the established pattern from `40_platform.yml`:
+
+```yaml
+hosts: k3s_server
+gather_facts: false
+run_once: true
+delegate_to: localhost
+```
+
+**`50_apps_infra.yml` task order:**
+1. Create `apps` namespace
+2. Add Helm repos (bitnami, influxdata, community)
+3. Deploy PostgreSQL (values-file + secrets from SOPS)
+4. Deploy InfluxDB 2 (values-file + secrets from SOPS)
+5. Deploy Mosquitto (values-file, anonymous)
+
+**`51_homeassistant.yml` task order:**
+1. Create `homeassistant` namespace
+2. Add pajikos Helm repo
+3. Deploy Home Assistant (values-file, `hostNetwork: true`)
+
+---
+
+## 3. Values Files
+
+New files in `cluster/values/`:
+- `cluster/values/postgresql.yaml`
+- `cluster/values/influxdb2.yaml`
+- `cluster/values/mosquitto.yaml`
+- `cluster/values/home-assistant.yaml`
+
+All chart versions pinned (no `latest`).
+
+---
+
+## 4. Validation
+
+| Service | Validation Command |
+|---|---|
+| PostgreSQL | `kubectl exec -n apps deploy/postgresql -- psql -U postgres -c "\l"` |
+| InfluxDB 2 | `kubectl port-forward -n apps svc/influxdb2 8086:8086` → UI at localhost:8086 |
+| Mosquitto | `mosquitto_pub/sub -h <node-ip> -p 1883 -t test` from LAN |
+| Home Assistant | Browser → `http://<node-ip>:8123` → onboarding wizard |
+
+Idempotency: each playbook run twice → `changed=0` on second run.
+
+---
+
+## 5. Post-M6 Deferred Items
+
+These are explicitly out of scope for M6 and should be tackled together as a bundle:
+
+- **`mqtt.furchert.ch` WSS endpoint** — Expose Mosquitto externally via Cloudflare Tunnel (same pattern as `grafana.furchert.ch`)
+- **MQTT authentication** — Username/password via Mosquitto passwordfile (Kubernetes Secret)
+
+Both deferred together: there is no value in adding auth without external exposure, and no value in external exposure without auth.
+
+---
+
+## 6. Decisions & Rejected Alternatives
+
+| Topic | Decision | Rejected Alternative | Reason |
+|---|---|---|---|
+| HA deployment tool | Helm (`pajikos/home-assistant`) | Kustomize (guide approach) | Consistent with repo tooling; no new tool introduced |
+| HA deployment tool | Helm | Raw manifests via `k8s` module | Less maintenance overhead, pinned versioning |
+| HA namespace | `homeassistant` (own) | `apps` | Matches own playbook; HA is not shared infra |
+| HA networking | `hostNetwork: true` | Regular Pod networking | mDNS/multicast requires host network |
+| HA external access | LAN-only | Cloudflare Tunnel | User preference; simpler for M6 |
+| Mosquitto auth | Anonymous | Username/password | LAN-only, no external exposure; deferred post-M6 |
+| Mosquitto placement | `apps` namespace | `homeassistant` namespace | Shared infra; other services may use it |
+| Node affinity | None (float freely) | Pin to specific node | No USB dongles — no hardware dependency |

--- a/infra/inventory/group_vars/all.sops.yml
+++ b/infra/inventory/group_vars/all.sops.yml
@@ -1,66 +1,67 @@
-#ENC[AES256_GCM,data:JmZx8piWEKVRnfMPiQ+b7oc=,iv:z/sqQXB6WMeSQSllCKMFWNKsCL0pG0/VN93oSYIZsrI=,tag:TKr9oHkc/xmbR7AUTuqUHA==,type:comment]
+#ENC[AES256_GCM,data:xBNTvsu7SUK9VgOsgxWejf8=,iv:x8UvPD8LKoRhnczbWcvPZol/Hi1LU85SrZHpSWWfVgs=,tag:+yBnZCDv5XeD6WXpiK2sHw==,type:comment]
 #
-#ENC[AES256_GCM,data:bbpaEWHMYCaNOfAvzAhNv+23TBMweiSvC3ZELo8CDg==,iv:sxqZUI2pRK5gsUYNnL63QtbfWflauNGCbbJQFDyN1s0=,tag:HhpBFIUqoByXX/aLrEND4g==,type:comment]
-#ENC[AES256_GCM,data:VLH17g6t63W1Y0DL7ae+QN0jew9BJxu7+YSONjmOu1YEu0GeLuEeTMEcSES4Ew25Avpm4BuJ+cEAi16mTcg=,iv:aKGgi0+5qE9dpMCWeVvIo3BYvkovtZSy0q2Fx/yxJII=,tag:KO6nWDvihjmxlXis0hxJ4w==,type:comment]
-#ENC[AES256_GCM,data:kKH80k+JUaGjbcGp44PPdmByERRkX+K/1UK5z0vCSc+yhDYK1wQGQgQGMi1cHflG8ta3XQ==,iv:mb8iwRzdV0Dke0q63lFjhWSzxQH7UEPPX10NthOf5vM=,tag:G+Mg+/HAhDs0+r6VKA490w==,type:comment]
-#ENC[AES256_GCM,data:Z16TzYyp3IxJqHFj3fp9kNva2V6FQSYuNUOKV+gDlgyWJmw=,iv:BakOdX/NX+pFj8R6IS6A7MrMI2YDtSbTLmmGl0HAOvQ=,tag:lKIpXkFw8bEPvaI2diB5UA==,type:comment]
-#ENC[AES256_GCM,data:PjpbRbdTGh5megjf53RNN7Z25R3qxLeE1ECpaZbGK/Jxhwjy7oMYqmGa0wI+E6fDKmcZ7nSexl4gtsBN,iv:ReO31wYDlirtXVU36gjShLO115+hUTY4i+lQpnxsB+M=,tag:a9KK6IWC58pLfQb+xNWrPA==,type:comment]
-#ENC[AES256_GCM,data:2GEivB31nqHrlcsg8z01DVs4M6rLTNLpjqEov01iG2cc7PH2xcdYczMbk8d3qBrIoSgNJmdaDIlvfdCJyG0dWmymR1TJmZFkXw==,iv:GuPGglCOe+w+sYm4kAbHS/pWdvHjfQmOAZ7Z6NC7+/I=,tag:3VTVIm5DepQBPmE0g0Sayg==,type:comment]
+#ENC[AES256_GCM,data:UirHBg138GE3iSpF/NUKEkUYHWMSlEfinG9igkGHLQ==,iv:9s1uVqDae/rcRr68eETZuoEb4YgEWe1mc6B5OFSdUkc=,tag:9jhDQDcoVB3l2v/q7s9OjA==,type:comment]
+#ENC[AES256_GCM,data:KnTG83HzDOdobabvFJjjOCWdJ1SrY71gPHVMUJ6u59g8Yx28+qJ8eTr7XGvRFmguw7zk74OgGEbY9yjMIQ4=,iv:gJbfCieH3yCeXvK6APbb/fjzvNQViulaw1ocPrWfUDo=,tag:5lqqBUvRUTSGQWwMVRaRTw==,type:comment]
+#ENC[AES256_GCM,data:wCQ1JjNQH7CKjBv3EtamzQpoq360tlMAuFFcI5D089plo3AcJ5oqJWa8MKrycM4KoH5B5w==,iv:t0+tjcX9K97TpFwSP5z0zHM8JKotncdXfB8oPSjYcbs=,tag:W4cl2sBdswmdhVbl/RWTrw==,type:comment]
+#ENC[AES256_GCM,data:UipKGqlLiZjCM9qCCzhO9n+MJJgXj5p466852Eg9pq6AWwk=,iv:a0WyHrkbzG/J550yrG4VYvkGtptqgrUbzTk9cYiY1n4=,tag:iuyCzVJS/suBeaDnbwzm/w==,type:comment]
+#ENC[AES256_GCM,data:QoR7+gWkmM666cL/ykQP3XhHseleQvRpU7YEKcWlPrkvDDy4VDNg2H38Q8+kxWUFbKyKYnjTyH0eOzCN,iv:dU+/ok5lyj0MApgY4ARA5+fhUOE8aB5RBw9IvfCFZas=,tag:KJhCREIV3TKj0NXcU50T8w==,type:comment]
+#ENC[AES256_GCM,data:JANejApCzY6xvtbbLuRj5dEvtrHQM8Tgk0Z4nkB2pcPNSu2241fua1KpVQUtIsrIPfyj1BTK0SCKTxceD/WOC2cC7fszlvsiqg==,iv:5cc1v9VU68Ckawj9plCsRYWJXcm4IWCh1su5SKxgZvI=,tag:WEDbYs2V2sb83E9Y4Pj8CA==,type:comment]
 #
-#ENC[AES256_GCM,data:wM3LTsdrvL1avs4noNNpPws/E+0d+s6TLbtHiIN7cQ==,iv:JmDE3BXtrx8qZlYYalBzM9jCpFD1wLPrtIBgwexqc3Y=,tag:BlFycSWw85EDLhdjtKfpYQ==,type:comment]
-#ENC[AES256_GCM,data:1A7iPm3XSwBeagagJ1Pe2JBm2OvcFx494sB4pUr1Wgsa4V6zCoq8JkC3mFp2r+mtGe0E,iv:0LZrukF0rQnZmEsuPm1HZD7s8ABJ2PfHTiNrRuP725I=,tag:JQeWoHSjTaCgXJTcEBAJnA==,type:comment]
+#ENC[AES256_GCM,data:vES6KWffHp3WjGwF50aMrnEGMZKmyENGpotESdfa7Q==,iv:MzYxxtztFVvb4jgjq1V2kNbFB5Fhni/PT9PCDMN75WA=,tag:RDaS7STy121FIKCEwd60rQ==,type:comment]
+#ENC[AES256_GCM,data:fv7nCzrHVKJlHlaMQ8vxDK0Feo10KqZ+USeYSbwEEBgzgcUc/GnVanVAWral88LqFAkq,iv:LzeimOk5iDqfosE4W/JteRZ9Z945u37hSM7jSdtbQCk=,tag:uLQqCBruqDdl1L4Kj+yHdg==,type:comment]
 #
-#ENC[AES256_GCM,data:0XU+eUzjN3nYsDW/37wqzDa/WHkzBdd6uA7pz+oegoUmnZfaAXnuBMv7kShdRhqp/SAwXXzCSQ==,iv:UDBuL30GeC5oaJbzUxreyCC8NdkQNFdbt6204/Daq00=,tag:2ZvcGzA8aPsZLS9fp0diMQ==,type:comment]
-#ENC[AES256_GCM,data:H6PgnL09L8jkCSeirYds+M4k9l5w3Xee72+m7/FwmD2bhjaZ+IBo/uUHQ2zrLj78SUS9JNv4e7bqDaiI,iv:yuLThgSWeMntmsPK3Kd/zhSMmbMqZxYhCYepDv3igPk=,tag:hXVbzqecq5AWmfVKcF2jKQ==,type:comment]
-#ENC[AES256_GCM,data:6kC0b3H1ZrI8epA1iPddAX9ovHeZZAokDRIVeNKa5ckR,iv:mxxmSISEKUOGssrJRc0Ck47vj0ioQN3Zgcrbh3c5DDk=,tag:zYdzWfMGxNIwb7b7YVG2Xg==,type:comment]
-k3s_token: ENC[AES256_GCM,data:Aw7gN7JUsiitEaPmGrPZ4pKFFdEEfK3dZZnba5ikzWRPENkigrRl/ODmCIbXUMZvW5sm9HVftz9QoYTOdUCoWw==,iv:ztIIuSIFcR7B828PFr70Oplpa5x0hv+FX7nMTqvSKuk=,tag:QVc06zRIBg/YMkxVUQMYHw==,type:str]
-#ENC[AES256_GCM,data:drEKWnm4nxx/AjJ2+lAFRKKinxFVFQzo7MFNCZ52KMJZFQ6Cp2bQ8dFKtej6SmJ0BE8dShCuJmZtW1LScIN/3DkRUMe5,iv:Yztr4TD+pvVBBxL8MvOUZ9UNtQL8y2310ZjXQwqpj3E=,tag:/B0vzJIZ2QEfRPwJ21wJXQ==,type:comment]
-#ENC[AES256_GCM,data:YCBir8gt0d1oZ8tVja6DZkhzueJO7kwSZaJileIEKAl2SnaI5/TSgmxSo6gs/Un0LQ7meUp6AWDcepwbh2967VJaFpm+xcyb4gr0vdp2RA==,iv:+DoUvxtr9PUISahUOTfJFZyJQZfjvxfADp50BYjmlyg=,tag:cT/tXQZX0GGd6538DZ/5XA==,type:comment]
-cloudflare_api_token: ENC[AES256_GCM,data:hV4n9qKPVTGIWxOcRpngXsVaUGLoZCyAOdwH8rJrUXQgrrfXS56JUBbIb2pKRkgUcNBz1Lk=,iv:wEehKQNCa+Bz2resb86ftm5r9iiTCsGUcSMF42LNHLM=,tag:dB2KUjRZXHKZHkU+FMUWFg==,type:str]
-#ENC[AES256_GCM,data:JdMypWmWsaX65O2f+kSkGZq3IEeoVDiv,iv:MvZ58JE6iSmmFI9xO2tG7y141QUHtklSx9U2FogbcRw=,tag:hYNIP9SsEtiMjP4bztdIfQ==,type:comment]
-#ENC[AES256_GCM,data:llsNbxhgxgB3Iy8=,iv:T75pQQ7rUro5pGB51fHH17Yn//Kxrj6pFA22wbAdNOc=,tag:5RbGZSv2uucTrqlqtpFqKA==,type:comment]
-#ENC[AES256_GCM,data:e4fZQbMiVTlv/cHSAwHeXVQQO3f1gUJ0YZp8LxJwAjlhPaHk,iv:yBvxHn8CDa2eZ2XiRqjSEY25irbpaj9McJVYcio9HcI=,tag:hjB4Bar9r3lpBC4etocmNA==,type:comment]
-#ENC[AES256_GCM,data:tuv4dzWOcq+0wovu/4BR4llB/nk3rz6ijQw+yidW0xm+u/g=,iv:lonDnqPLH+apn4Ulo0JHc6mj8Rjvvhq+MscGGrP32kY=,tag:j9DL8rIdTS7fD381aNxzwQ==,type:comment]
-cloudflared_tunnel_token: ENC[AES256_GCM,data:zL2v4c/5vUzUJKoCxhG4qdd7Y2GmPL1TsF9ZIJL6O73a55EOC6rat5aM85Ct4kUi0OdS2f/0c15kj25Q/7CxAy8/kJqtpY8HD/uzFJw0l+oiIoW6jikcWH/YFFlPupjh7mkBdwYsmFd3dyIJEsfmjVGJZyp7/TS9C8Yzs0a28tx/fmI6VJQAjRvQ+r6yb4VG3lZudLrdxi4DDlAAwAX4fHZNFcX9o4UImE8MWYwk6RZOGpZ4,iv:eyR2vZ+sPaz99KYPmdgoddQ5VrNM4WGauU75ZbhM8pg=,tag:RapyiNpvWqrXvGFR5ZWJjg==,type:str]
+#ENC[AES256_GCM,data:5abcwIIjBpYwUAcvPmTewmmlSXzxDFibNQNkwJxZhyeDJcnm+/nnrF2LeAe3bVVCt76z1mcdgg==,iv:c/Y864pnb/9sQiLizuNI4J5KPJxt7SxrLXTEnmqkZXo=,tag:Wi+xWWTagRAwhVzpcQu8SA==,type:comment]
+#ENC[AES256_GCM,data:Qkpfy5HhJZ/XzCqj/dvSuHru2iiw2xXrchCoWLFdEMoVzjRo3/7Op+OiuzEVitZuDCLOYGr4DuMagm5B,iv:WGlv1fC6VAwZjNxBQ8wNzv1U/sTqNlV73GrR2fl2408=,tag:xMVRKr5jMKCCyfgA6f61lA==,type:comment]
+#ENC[AES256_GCM,data:NeQlqBctAmOS8RKTtBM4a/hqvyRmKotZoEy72qUle87c,iv:uJQf77bf5bas4G/dSqzeCPshkusEaFMQ9rBrPgRuths=,tag:3Urs72w9uyd5AsiB6BeOrw==,type:comment]
+k3s_token: ENC[AES256_GCM,data:vDwytCN+5dTVLeXiAn7nNb0H6DsBZ/1Vm4nuf2T4seYrFEK8/ktgOrbjLJ7uqw11XlCBDlfqNag/r+cd91051Q==,iv:wJJD/ZIseqdDYG3R4pmlo6AYe0yklg6kQ+5AFlMy1Us=,tag:13RHpDrvelXVaxqm6hT6mQ==,type:str]
+#ENC[AES256_GCM,data:pI5g5UE0KMpvz0K+6OmlJQ6LqVH1zGg5Wa87ilw4+iNvGPayKCm7lCm5Dk2z/obKnBPxqaKVkCVQf6OXWNKCCDDmbPJY,iv:C9zT48uQ2bMKQv/dpKlRYW669m5asfr1T2sJrYxY4ng=,tag:fluGuav4gWE4kv+8TdYELg==,type:comment]
+#ENC[AES256_GCM,data:Ir5bCAKIn5mamjY1MOquTx8jIidpumR9/00ITmicxl/4h8pSvFe/DBM7zg0wk5SPWBJ7SEQ8LEbSjkIERekJ6esu+PzChnWIfx9Z+7swpQ==,iv:ofQ9tjp4+vqlHvtzr2J+2dYnlsHYTIQRL/4lGk7Ciek=,tag:rPE5RHAG+PavrRWiFbVP1g==,type:comment]
+cloudflare_api_token: ENC[AES256_GCM,data:9WhtblsUcBtejcQxCG3Nac6Kn427hKhXN6GCl31oqKVD7neI4eXpd7LlGdEvGJQ2omDWhAg=,iv:jTlBC16JN0myneTXdLY73nch5vKdU39RYS+xJTNkjn0=,tag:pJ2D4IQ/sjsfqMbTP/eu0g==,type:str]
+#ENC[AES256_GCM,data:IWHQ3NNwq0E15ldTjexq5KRnWzJwKLZf,iv:OReXDXn0EqJQvW8C5zy2lAzt6Kih4jXN6rvEjKz+SOg=,tag:i6vrTaqyfVs7hMk9/hZPBQ==,type:comment]
+#ENC[AES256_GCM,data:/t2wCyrp2RBmX94=,iv:izwcbzGEEWBVVohuLfOxJKw331nfUzutd9dCIRVWRbw=,tag:czs5nejqyoH49B7/34CgQQ==,type:comment]
+#ENC[AES256_GCM,data:m6Oj+S4M6LMERSZc6+0xT+mdoGYY8pODyVtT45xmrnzY1w+G,iv:9gK0dNfySvfPlnphFjxdokV/nbkqBF449qZofDLdhhs=,tag:08N1R2XZAv3QvRN6AvJDAA==,type:comment]
+#ENC[AES256_GCM,data:iEngCXUHYRvKOILF1hA4zlYl392cItDpw9yr4HtZtk8tUJA=,iv:zTQbdCeTfK8hgVagDokc9ChJvx+QXx4KvCcEYU4FX0M=,tag:FZQMR4gk/6Wm7syak5tUlA==,type:comment]
+cloudflared_tunnel_token: ENC[AES256_GCM,data:MeNV9Wc5nXUaNXrPGjrKvtMZ0YKnRomTVNgJW8XOp867RiqQSKfUmD07SEKol2Le9IXM88KdNQYgy4CO3WuWYzo0i3Nn8+v+XQ3M8Isye81ikVpGgisAsBDPjFYO3m6yDVlaCdi3wlUXBy/cGREZ3t0XaqbTnOf8Uj86aDmGSOAAz7zQ5UJmgTt7W9KWcCxM0f5o5mRMqgT4ph60C2GwKu0LeUwcplY2xArdPVJ0IC2+FwjI,iv:ltkfs5usWTS2fVV+fcHIpOiDXChfac3F2+XwbTtuoOY=,tag:lpn4Tr//nghv++hcXADpFg==,type:str]
 #
-#ENC[AES256_GCM,data:WlX3Ge8I4LwTeijP5jPd8qaYh7gxwiNhAqebbzESeFEK14AuvSq3Q6dD9W8+ZpJKKhnP8sMamp11cgYwKpYoJ3BnHRhnvcsq+Q==,iv:nRXCZbsEBjLo9+WKGKU0b3HliP2eRGDsRh0Ve8aRPB0=,tag:AJt16RYYgihLSrRBZIeFjg==,type:comment]
-#ENC[AES256_GCM,data:AiFmBf49KN16/KfEQ+l/yWgB35ed718C6hY3gXfYmxxu9jtxAGkp4FBh28xPpKg9xUy2h8O6N+fTWwipbFHXSFE=,iv:DCGWg4X072yRQ9j7dfPowv7kVAYin3TP4EPz9xgfCB4=,tag:hBfrew2/z0CyXqUupIMkLg==,type:comment]
-#ENC[AES256_GCM,data:qmuIzM815LA1sDGM7JfqrMGHhVMcnUpGptHMD8IQksKbvZaWLfge5zJNdMZT810qVGH2qaIipbXtVbbLKPV0Th+33pyLbmXgkZXZThOtUpX8TYmKf2HlOxB04JgVG0Fgx5qnKw==,iv:XumUT4yKe2Hen3dp0AwQgMtj0IzacTjdA0fVndwfxEY=,tag:erYPSCVcGEytCvcNoTxcfg==,type:comment]
-cloudflare_account_id: ENC[AES256_GCM,data:IFfp5Wjxjq4VW9favN0D7sPw/0AUSI1DhNpPNEsviHY=,iv:TIZQuTXW4epuy3E/z1H6oZHIntwTyyFIsOflpAiSLjk=,tag:wI0bDILGRwS/ZB4nf8Muyw==,type:str]
-cloudflare_tunnel_id: ENC[AES256_GCM,data:S66ZnDxrrtejhEvLM6dA/I/zpesxIaC2suhZrJczJ4HFvimZ,iv:QUkarsEEP9WdHmpCh1p8Z9joGHcJ33UlwCb8Ltm0Dq0=,tag:CZ+rDQQ+Uw9L3B+TiXzFrw==,type:str]
+#ENC[AES256_GCM,data:H9+YrUmeb+bfezVgW4S06N0NVka3HdVltW/o4WR5bSyTEOF5wOxlq/NXLV/ORco+bPxhFqA3lyq9MTSyYZhZwFbzlDllkxWOcQ==,iv:7KfpTym4po8bUnwEdoSGRK0/q74oGeJg6wilCGakVpw=,tag:LFfmZffc0Xad4rJDgiGmNw==,type:comment]
+#ENC[AES256_GCM,data:NXJz8PjV1Cn28Gf4XIrZ2t0bjPJF2hKuAOlzxX8a1sXlISAyJQjTzBbk2Yyn7F/e81T7TNi3cWcp4UsfmOv7NuA=,iv:1Uc0bB99vlcdf8YDX9AqJAanKCkUzUV3r0xFzhYsJYI=,tag:w9/6YHHsqd08t1v9OnnKbw==,type:comment]
+#ENC[AES256_GCM,data:MWbd02dAAU/JhPjBPlCNLM3cPNnyaxJuMQAiaLjGp2vuIjBbHfP5rYAN7pFjMqnGsnPLuRwPOlTdBf8umkQFHTLJrgURPw7QSkR1SKLmF/S0+uUkdN6Bzx/i8ti9qoE1RtleAQ==,iv:LB/fubvxBUUph/ai7OJj3F9bJSjSjhIINku5XdHqcLg=,tag:vOfM5tWUnZSlYuysfnTuxQ==,type:comment]
+cloudflare_account_id: ENC[AES256_GCM,data:B05UMzwnW2xYIBlhi0pvZYkm8zlFk6LzsL0K684n0gQ=,iv:C3qVjzYXmMDCwYY7fTRMefze1DPOC1XUrKwZ4HijOyg=,tag:GLhRITcsCObheM4CklHW0Q==,type:str]
+cloudflare_tunnel_id: ENC[AES256_GCM,data:BqNY/PwMFecoQOvV92UlK43xM7nRledhwzbuAmED+D3Rktx2,iv:3A1gS35d1tAHDefd+PrIGgmwysBNopCoVTe2YcbR/NI=,tag:itAq8sHcbJ8XEnhp8BcfDg==,type:str]
 #
-#ENC[AES256_GCM,data:5WLn2ksihJiEiUuQNbrf/k03Rw6QRrwgF5KLTPP1d02uvYZq2qCrGZJNbtFxpElv9SqkH0Dc9tDiW9HSnh8O/bcVbeZsEiPPw8saGQ==,iv:hiB2jk82b18uoCfyX579urP15fvzU8kHm7fP0uY/FxM=,tag:/wQfDY2rhU3UIfxMGxsJ+g==,type:comment]
-#ENC[AES256_GCM,data:KysoOi/qYvV9SLrrjjiuZj968DzR4tK+Ao8sQYtIVo0YDLlDcDH86YUz82McA9FKPri8gUYznapkZGdlF7jL7xfXLOPFj54FL+Zr6T8SKQ==,iv:CYSMQcpDMHLgy7COo0UJbyzCx2Mqnx9paokEznd/5yA=,tag:PID6VIAAcXtyMAJ1oz9CsQ==,type:comment]
-#ENC[AES256_GCM,data:pztSrj9E6nzlkRyCYAQMpOUWyRxETUWDGNmvRsaxHNhtmHJkH9IOoDZJmnYQ,iv:QDOXmeGzu6n/wOUA6YOg0eSWmuHlPjZZhQX8BGNqSvE=,tag:irVTMZqikFSPjr1851BDHg==,type:comment]
-#ENC[AES256_GCM,data:KJ9N7zIV+AH1vX4bREk72qjObYqKpkNf69t3QIlLUeV9AM1cJ88xQSnod3tX0amFTBhW0CsOWNxwkNv7zeZjdndhie2PBrn/CnFpn+IV7+H/Zq1zSQ1410UPviMEBmQ=,iv:B1Z7IIGTvDbnRjlWE3qJUsY1wkahpLwGFYdxEjihmm4=,tag:FkBfSlS9c80dDPsC9+IpOw==,type:comment]
-cloudflare_tunnel_api_token: ENC[AES256_GCM,data:LYQPsXThWLnFXC3Z1P8MkQhbZ7vY8gJAJ516N2F8MuBHYxOS5IflDsFKlQqzWI84sG+jbdY=,iv:UP63gNtGdrIlhmJd5On9NV+le5/xcwkII1jeu5oj+Tc=,tag:LBvZIldbVYkg4CitXpQIPg==,type:str]
-#ENC[AES256_GCM,data:PDaJDA/G2r/4RTbiDK9QpBVjoO+1JX8/4ywsrcfI1LE1ig7O96bQpIDk1ce9ZVkk5SGAOgoqJgqc1TA5qjmxDdoyx2M=,iv:MKFYXjjI+L6Tg8EpLcd3M+2jKZ6Xzui4IRbR7jsNoUk=,tag:Z2//v5sjVuCqXk/yJg9C+g==,type:comment]
-grafana_admin_password: ENC[AES256_GCM,data:FOBRBxLP1+EijtmYn0+5kq4gfz9gxorAzE1KlEE9OFQzjnaPfKYGCGkvejJgLMUc5DTrqnE/MO54uCbYkMmg6g==,iv:VbWgz0Q+b9FxttgJPy4m9dK7/LZpsFZYrZdHzreUc8w=,tag:+C3tUwZYXDjxQKjePJ+yWQ==,type:str]
-#ENC[AES256_GCM,data:RlaboDSW0Qo/usVIgOeCzRTgUY+tULvTB/dOTjuFI3fRDl+nPDLS70E0AirlINo+t9lRJ71uDetCGVJ+g7GX62Qsyp0ebvipsPpTMy/vBn3a7kCqGLd9YTMjjw==,iv:RN3D8sBnYVrbtsB4wFFATNWiqCmQ+SXxb+k1BhclLSs=,tag:HTgmrNpbgvNHtJr7BlZKQQ==,type:comment]
-#ENC[AES256_GCM,data:0u20uHwdAtcz6WfvVgSY75q6AJb61//arJXt7vMJkiWHsfUz,iv:4kppxNYCFdVzugN6j0qAYizpMNBa1fAUrqu+IvAN/1Y=,tag:9a4GiY7YcLqGKqGT+pa9Ew==,type:comment]
-#ENC[AES256_GCM,data:OuE3XN8ivKHgJQMx+iQAtYyibKexlyDA7l+wZc+sQaLgMulrIIF6Knu2AIc4pWDgX7uOACd/LREq34NxmwLvh6AQtZ7NN75KdlY=,iv:FzrxKYbfGkB+CNviVdCRY+oU6OwTaH8vWtt3HYgd0sw=,tag:A61bnd1f9XFjxge36bWBkw==,type:comment]
-restic_password: ENC[AES256_GCM,data:8a1mA2/GJH/xwDQh/QX9Eu7T/Jpq05GNVbtzyVNCrJKTZyHxDioN7oxCdVNr4fVF1vLVNaWTIYpFv3nNHkMW/w==,iv:cW0yWA7X1iiy2GPKlQXPnognvDhddobuMdwa5ydwKzE=,tag:1C6Yj36wkCM7SqIwkNf9nA==,type:str]
-#ENC[AES256_GCM,data:H/ijUNxxwB5PeaDl0Ble6MzW6BJXNb44sqLCSn4yQVQ3,iv:XiXDMl4etkKlnoSZGbSgA87rJHAVPfNSlEJglOadRGg=,tag:fT3bjE/wQ8TWPxc12WL+7Q==,type:comment]
-#ENC[AES256_GCM,data:7N+5Hl68yEriAqfRMkAl9V0VQ6lMdLpTVLZaqY7hAtuM5T2UjkehwOCPZi4w8EmL2eDQs1u9s0yNXloI//3/ombE9zfSdhK93DEy0ViaFVOcqn3nj6G02TruAKJKEjlsdH0tCzBbE33mJui8WPoMjKbOY+w=,iv:ZlOPay+wkYEZYOI1IF7iXG6F/FLA+NlT8TOtYcmCj4Q=,tag:RiSHFTGPpDxkb5dsxCGO+A==,type:comment]
-#ENC[AES256_GCM,data:u7FVYgOMK8xzgumFNN+kBJ0HQt4GoKiY+pblxTcnpPNXOCerSlbOL+s6bQvDYEaEnF+uIWtVbxj42qxorQ==,iv:AKiUOejedgNsmT7J5jwSlpgNsfvGjY6MZGiUdZpH2wc=,tag:jOHaHjlAt39tec7DByWHuA==,type:comment]
-alertmanager_discord_webhook_url: ENC[AES256_GCM,data:XIYOtnxP2wtqUfPhwazg1czw8U4SCRGxWNqQP8ig80yxWKmuHeVnxO9P6svTLlJbWrtNz0XlLEVDeKU1vJbom0+KK2CRDrZKgR12sPmXmTi1uvmIK4fOL0MDT+HyR43vXKSPWquNmyMZBjtQ8GaL17M4lKn89Xk+eQ==,iv:adQNRT+O2EmXsU3iGQVkAiT/QecbCgn8oh2qLFpffd4=,tag:m716B5XAbwzkI1hGMKb0IA==,type:str]
+#ENC[AES256_GCM,data:I7Y1hov1CpqS9kDkDikzbl+Fx+OoeA3e/no4Wn4ZpvNbZS0EizHbO5uy9t4SDoTyHHHfX+Xsdzau0A3MsBayTBXHZOp9z75QDa6iGQ==,iv:owRVYFMelBOPyzxodxnzzLThEzqALx+50HLQis2bo0M=,tag:Ha0iGCFj+UXOiUJIAWArCQ==,type:comment]
+#ENC[AES256_GCM,data:KjwOGtyEu42vvY68mpf6KhK0il2M5cW9Z30IZZABeWcQtUbJGMOIWz1c6SU25CMQaETX1JDaHc0N3rNq63xfDLRa/ZcAk81MfzLHggvlDg==,iv:kJ3aBqv8379Ub/VMejXnoreygiqzcGwKDCxTXZHjVdQ=,tag:p98MVIydSr6eUVgNBbyo4w==,type:comment]
+#ENC[AES256_GCM,data:CoKm+xW40rPyrIqzBwYfLPe0nepeu/oshKKTf8mnHgc0GQdUv4KNiJoXRWC9,iv:9dUENJb02KdUax86L0gVpjbG6qSgQngyc1n2f16yM/0=,tag:h5L/vHzjpuFolhfyo1Ruuw==,type:comment]
+#ENC[AES256_GCM,data:HhSzYcqJWSe/yQuoWojFB5+4xNYQdSO0uy/8jgi2LDfKYOYuIQnPmrtf9ByL81BX1i0z4DU67luFzXbWrxXfhI80MT8OhqAjZYjjcMFff6qOA7R+Vw9jKyfO3fwPG44=,iv:/ksNQzuoOQ9OrT2+yO4cjYiu5Cyrh2WVTFxsMTyQ7D0=,tag:zCtVFlwI4hfbWL76uaCP3g==,type:comment]
+cloudflare_tunnel_api_token: ENC[AES256_GCM,data:xEB4VFFjXhX6e87aveovkk3vfAp+Ba/rraFhpW3o146umDxuqTHEH3sRaROmbrKUHQiueZ8=,iv:CCU3h1UM1dYUZJBrqpvMrkfrEpdKQg+1EqoHbmRWlVU=,tag:y5ffKessuKnbwYceRcnegw==,type:str]
+#ENC[AES256_GCM,data:bgVEh4S9Bda7Vffc7L17lxr8djSL0f8f39Uk6/a1gkEjx9z4rmKXSLArJ/mzxbNuHoNuyoQN6Yli0r0KiL6F9aBwfwo=,iv:ZwtnZjy+da3VoELhVaHINJ6XYYK88BZL6FMQhfLBF3c=,tag:F6pgDhCXrbUUwaGTcOBRgQ==,type:comment]
+grafana_admin_password: ENC[AES256_GCM,data:86GpVeOTaUxkbvfiKhLLDZImtpLC54IJsoGZGJqwoL3R+c1PEFbxTiyTvvp3Zrpk8MsRp2TD32jqs77KauMx4w==,iv:F2EDEeCPxea5BzgFad7k5ti95+/8gZJGNHWQKoT7rSA=,tag:jZxKBUHnDnJGtqtN5/Ngbw==,type:str]
+#ENC[AES256_GCM,data:DOs61xvvv7Zy8sDIY0ANM6UTHsJISo5r1pE1eFAkzcMyuOEMSq9XYBZ+NGnKoF0jAUzyoGzcB7YDBtfqE11Fhl9SgDHeX8TV7h7UHxBZneGCtLVxCZE6mu1GFw==,iv:RKEqTPcFWlNKHlYLbl3hwQ5SpVUyzZ5YvYETtihR/iA=,tag:MYIJ3lFw6V3HGRUWCxoqIA==,type:comment]
+#ENC[AES256_GCM,data:60l3sv2YuhY7i4XTpSI5sbEFsyDzl3RJuH/gBtdqzppIJV/j,iv:vqPNWht7heDQWN20rtuLV1hnbm25h2rXXpZhkupwMgc=,tag:RGPNvvkssbgovjQymw8WoA==,type:comment]
+#ENC[AES256_GCM,data:8HImKyOGf1HpMG/ELoz8KuD5RUYzsCoPn9DPxpVzxBddQR+Se57eZGR1FRNfBqBrwgRdL7Mka5IN83QLQmSGvdQzHI7ttwypcfU=,iv:AFE/5JiMz82HAONE7VtdBozmUmwplQWCUK7eRMDmWXI=,tag:sc9FhEYmCTVpFjq/E5GuCg==,type:comment]
+restic_password: ENC[AES256_GCM,data:kTzr4OeHOrlq6MlY9zF+4obNZ5aY8vd/a1Gy1+CL0WeGKKEx7/sqK6Fh7AKTdTkiCp5YEsEZBqmBVChS02Bgdg==,iv:AXw4Fm1SOBCIygOoVDz7mCrU/5d2PUuQ++/ybXLrP80=,tag:9+x78ZXUqwFHpfRhCAyhYg==,type:str]
+#ENC[AES256_GCM,data:DwmQMmcwo2dIzOq/F7WcO/8V4UMMEBc6zbMPdxxxwsaU,iv:iRwDsPwsdHOk91UzKLOnTbkURKAKKFGT8RAZ4EatfK0=,tag:ytTH8YOcnNT1Q6EVEFj9EA==,type:comment]
+#ENC[AES256_GCM,data:PjQTOPgZPZxcCKx3x1+rHXifPoON77WkIzVCGlAgwbSmDTm1QIWZ8NqPhoxhNvnh/msf1vOqK7O8rEyXS2OvCjS4wWNqhXDlP/800fCxmrUUfQB3Vtk2s6tSDssI9Ge8oM7wFh8eEYtI7hP0q7LlJdfZLko=,iv:MX/yXh4cqbpqgEYS8gH6nVddtMnw1vgZgbDmdf80DW8=,tag:2ZHlXFifE6/rX+hTe4I3Ew==,type:comment]
+#ENC[AES256_GCM,data:71dzD+5e7WNu6SpfIqu5Z575PSI2ZExu082H7JxIiqGZoNicMp/14SUhGl0qdAj3d1A4fBzUlk/7Ap8VrA==,iv:65qOt4o2t3Yh6utKEAgoTuFf1F9c4iE9HsITDrObZwo=,tag:EASRHE7eqAFLK0NcT5IJLA==,type:comment]
+alertmanager_discord_webhook_url: ENC[AES256_GCM,data:saN6tnBV3eOGm6gmD1SsVnPygExYbHz+zXUK3d844Wn8lr4y75QlcohIX7vJ/6dN4ElP8HpVC7+scYWlYuzjmN/nZslRP2QVvZo1dzB5CljKB3TtbQS+4CZgw5UwCxs9YbhDJotVZjjM+EygjuwqRVn4j+EjwxBP+w==,iv:dO7nmqC8IPpOqE4EVr/nAepnnJnjTzDarnHQC57rqpA=,tag:RHW74kc/CzAykPG8I8gNXg==,type:str]
 #
-postgresql_password: ENC[AES256_GCM,data:GZ5a2gq3hQUcAhfMHkmrnEdD3BHccn492THpP8uplKM=,iv:gzsEw5w87TPI6seXpKKRuyVKNBUi+vEAaOKeI3DVi/I=,tag:2i78dBvRAGYmzm78Ur1qNw==,type:str]
-postgresql_replication_password: ENC[AES256_GCM,data:+2D2+LfoyFKiL7XDRV8qeq0MZEK/Yj/x/FnBwjZBIfY=,iv:XHtRm4pPmI7fprjPN814WUJ6IbtAMGWTOD66xHmDbuw=,tag:/GqJelGgYVs2rU4pY6KwVw==,type:str]
-influxdb_admin_password: ENC[AES256_GCM,data:p96QEDS7NbyUKUK2YIRp/tqxTH3nmfR3,iv:Na/pjNgEI2UUP4xzJwtZVRes21VQwcX4LwExUSIl7V0=,tag:6AZA8D9jmLM9sGX8JOR+Lg==,type:str]
-influxdb_admin_token: ENC[AES256_GCM,data:f+D2uO9bjgwwjnC6oS28Uydbs6l9n4mTn0Do0ilwvrRAvKUH7U21OMRnkA7LtLEqodfKqGu3ynBt6SB7OBaVZg==,iv:+wM3r5zvZKTOIolKKcXsZOG3DcQOT+YveS7D13BPucA=,tag:5luyEXYf6YNWfpdhpb5++g==,type:str]
+postgresql_password: ENC[AES256_GCM,data:OdaJiUGv+Mn4IWX+i9x/mo8IwQGHrkbo0/Pi4eCvhH4=,iv:lvzzfHHDhwHCzdNFl1xtDBzHWiGI1R/PxEtFDMq7nao=,tag:O1G5WBxt5eq4wGw1MnZjow==,type:str]
+postgresql_replication_password: ENC[AES256_GCM,data:lvwQnIYiNBm+b9MCjewt4jKDlWxM63wo5xrzQrnInbk=,iv:yyuXXslPgLr2qC0/zYw8Nhp7Nsv7hzhJPsk1Tzxv7q8=,tag:6kbVhKWHO5GynOr99XH/vQ==,type:str]
+influxdb_admin_password: ENC[AES256_GCM,data:2de8AuRZV24pKXMQKTMjttjHA+3ljv3t,iv:zCB7GdJNT3NUPPVLqikR97hgOLp6svbUp21QfvZlNYk=,tag:vscPSlUqNaqPum2JTr0h1A==,type:str]
+influxdb_admin_token: ENC[AES256_GCM,data:UHQiJ+Xqq80BxyhCjgXGyWMNmshsQ6aNPHW5GPjDGLlHc0aExAG+LlK1b+osXoQr2wmDaBEFx9Ega7NPoVrMug==,iv:Fl/3BBIWhXRXzNodE+ZNS+58fWgn954NfA1JtxE5liw=,tag:nJHgdDB1iAe9NZiiYXw8PA==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:dItbouQZ68MYD4woFhI6mu0OkSsr7ky0YlZtEmHduUKFL09u6JZE/w16idBzmFcWbgwaTaI7Uq5zKDpxOYMbgj+i2C5MOZTXAkW7Fr/8iKCNTjAep7aMO4UDyFNm7Y8=,iv:bncLXIXsYpvL8DTeIN8vwW9M06uBuJzIsjVx2sM2uuw=,tag:XJiOUbz1arBE8gJ0RjcUhA==,type:str]
 sops:
     age:
         - recipient: age1hemf3e85hjhvsv8r5wx5s844uemug5jtaqpjfx8sefsu0kng0vwsyv5xlf
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2SkoxalJuQ3dpL0hOT0lN
-            OXhkTGRJeTlkK09iS3BkMk1kOWxURXBQUVNzCm02M2xWYmt1dWV6UXdLdURZRDZU
-            cXdEdWVYWGVGWEZrRmlLQkl1bC9hU1UKLS0tIDJTOUhWWnRBYXE1VTdjaG5vK2d6
-            UHVlZXlWdXhuVVM1SXpjU3R2VklQY1kK0I4XWLy9bSxKEAozGiPYyPvOZqXVmy4n
-            hUC1QY6l2Flaa5ffno79NM9A/r5z1f3iSmElRF55LcTo65V5KS7AAw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtL2lZa200bkZxc2sxaWUx
+            UzB0QUxldFFiQ3BoSndDWXMzOGk2RHNreVNFClJpelJXUDJLbko3enlpWXp2Z1ly
+            a21McHJ3NkEwanE4UmRmU3l4NzY2M1UKLS0tIHJ2NmJsOXBDZFpzMlEwN05FZkdu
+            azc1ZGtMT0tlL1FzS01LM0dVRTJRbUkKpAeHatN5+W7DvxFKtSDjUHg0vr161rPL
+            7vVzM2cEkG668Gnd0iKxSTlwz/u7mtkDPbGK7TId+ekaE/IUchCowA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-31T10:11:01Z"
-    mac: ENC[AES256_GCM,data:zwl9URg0LUJhQEIS4Vj9Xuv5G0PEUR8M5jl8wNX5vmeezgBgN5rfIGnRxIDTiyjje+jxyWJc9seiQP1MbEubmDFmWHOSDCOS84K+cvpQjMkQUQ1gOlFzXqqYLWlfKbwuhigKGFL6QEph+JN5S+3C3f/3S3408XRC04B43m6wcx8=,iv:DNcU+XUdMKHamxoiWBUkvxf93+WlNoWZ+N8t6VpED0E=,tag:hwx6oe+4/cZ6s02f4MiAsQ==,type:str]
+    lastmodified: "2026-04-09T10:54:30Z"
+    mac: ENC[AES256_GCM,data:sBeaMlwRUa38D3w+zSVl6A1zQIJo719F+kV8IjIc+4TseBmF7qUv1ZzFHd6IGYSv2lnO16DDdQpN8v1gZR53Y36TCKmUoKT2hsdCeR8Ri9MV/LPBScMeiX7L11hFdfqKJ8UOnR7cQfQhlE5vHyO/j8DRKHCQn5RlnvZk5kOBqmY=,iv:8TvjwASqK2rAbKBurVcfRi62Bzw7k++pf2TsZFrh5CM=,tag:JMvYjyzX+N7ilhO/J6q2pg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/infra/inventory/group_vars/all.sops.yml.example
+++ b/infra/inventory/group_vars/all.sops.yml.example
@@ -59,3 +59,7 @@ postgresql_password: "<generieren: openssl rand -base64 24>"
 postgresql_replication_password: "<generieren: openssl rand -base64 24>"
 influxdb_admin_password: "<min 8 Zeichen>"
 influxdb_admin_token: "<generieren: openssl rand -hex 32>"
+
+# Sentry DSN — obtain from sentry.io project settings → Client Keys
+# One DSN shared across all three homelab microservices (auth, device, data)
+sentry_dsn: "https://REPLACE_ME@oXXXXXXXX.ingest.sentry.io/XXXXXXXX"

--- a/infra/playbooks/50_apps_infra.yml
+++ b/infra/playbooks/50_apps_infra.yml
@@ -27,6 +27,33 @@
             name: "{{ apps_namespace }}"
       delegate_to: localhost
 
+    - name: Prüfen dass sentry_dsn gesetzt ist
+      ansible.builtin.assert:
+        that:
+          - sentry_dsn is defined
+          - sentry_dsn | length > 0
+        fail_msg: >-
+          sentry_dsn ist nicht gesetzt.
+          Bitte in infra/inventory/group_vars/all.sops.yml eintragen
+          (Sentry → Project Settings → Client Keys → DSN).
+      delegate_to: localhost
+
+    # --- Sentry ---
+    - name: Sentry DSN Secret anlegen
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: sentry-dsn
+            namespace: "{{ apps_namespace }}"
+          type: Opaque
+          stringData:
+            dsn: "{{ sentry_dsn }}"
+      no_log: true
+      delegate_to: localhost
+
     # --- PostgreSQL ---
     # Hinweis: bitnami/postgresql chart nicht verwendet — Image docker.io/bitnami/postgresql
     # ist auf Docker Hub nicht mehr verfügbar (seit Bitnami Registry-Wechsel 2024).


### PR DESCRIPTION
  Adds sentry_dsn SOPS variable (documented in all.sops.yml.example)
  and a kubernetes.core.k8s task in 50_apps_infra.yml to create the
  shared sentry-dsn Secret in the apps namespace. Used by auth-service
  and device-service Deployments. Includes assert guard to fail fast
  if sentry_dsn is missing from all.sops.yml.