### PR TITLE
fix: scope Flux path to flux-system/ to exclude helm values files

### DIFF
--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-system/


### PR DESCRIPTION
cluster/values/*.yaml are Helm values, not K8s manifests. With path: ./cluster in gotk-sync.yaml Flux recursively discovers them and fails to decode them as resources.

Adding cluster/kustomization.yaml scopes what Flux processes to flux-system/ only. The apps Kustomization (via apps-sync.yaml) handles cluster/apps/ separately via its own source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Kubernetes Kustomization configuration for cluster setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->